### PR TITLE
Only add descriptor layout field for extended layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Planned improvements, PRs welcome:
 Less likely to get implemented, but PRs welcome:
 
 -   Support for 32-bit architectures
+-   Support for "old GC layout"
 -   Support older block layout from before the introduction of block descriptors
 -   Discover and annotate block stack unwind handlers
 -   Find and annotate byrefs passed as arguments


### PR DESCRIPTION
This is to gracefully support ABI.2010.3.16 as per https://clang.llvm.org/docs/Block-ABI-Apple.html at the cost of slightly worse support for "old GC layout" that we don't know how to handle anyway, and not even sure if relevant for 64-bit architectures.

Intended to fix #3.